### PR TITLE
filter: fix SIGSEGV when stream return error

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -911,14 +911,15 @@ static int stream_list_init(
 				last_stream);
 
 		if (error < 0)
-			return error;
+			goto done;
 
 		git_vector_insert(streams, filter_stream);
 		last_stream = filter_stream;
 	}
 
+done:
 	*out = last_stream;
-	return 0;
+	return error;
 }
 
 void stream_list_free(git_vector *streams)


### PR DESCRIPTION
stream_start->close is called even stream_list_init() fails in git_filter_list_stream_data(),
but in this case, stream_start will be NULL, causing SIGSEGV.
